### PR TITLE
Update Double DQN.ipynb

### DIFF
--- a/pytorch/Double-DQN/Double DQN.ipynb
+++ b/pytorch/Double-DQN/Double DQN.ipynb
@@ -69,6 +69,7 @@
    },
    "outputs": [],
    "source": [
+    "os.chdir(os.path.dirname(os.path.abspath(__file__)))\n", 
     "path = os.path.abspath('..')\n",
     "if path not in sys.path:\n",
     "    sys.path.append(path)"


### PR DESCRIPTION
I just add one line. When exporting a python file from this .ipynb, it can guarantee the correctness of this path.